### PR TITLE
slash-bedrock/etc/bedrock.conf: removed share for /run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,12 +120,12 @@
 #
 #     make check
 
-VERSION=0.7.6
-CODENAME=Poki
+VERSION=9999
+CODENAME=Anubis
 ARCHITECTURE=$(shell ./detect_arch.sh | head -n1)
 FILE_ARCH_NAME=$(shell ./detect_arch.sh | tail -1)
-RELEASE=Bedrock Linux $(VERSION) $(CODENAME)
-INSTALLER=bedrock-linux-$(VERSION)-$(ARCHITECTURE).sh
+RELEASE=Kreyrock Linux $(VERSION) $(CODENAME)
+INSTALLER=kreyrock-linux-$(VERSION)-$(ARCHITECTURE).sh
 
 ROOT=$(shell pwd)
 BUILD=$(ROOT)/build/$(ARCHITECTURE)
@@ -205,7 +205,7 @@ fetch_vendor_sources: vendor/linux_headers/.success_fetching_source \
 	vendor/busybox/.success_retrieving_source \
 	vendor/libattr/.success_retrieving_source \
 	vendor/netselect/.success_retrieving_source
- 
+
 vendor/linux_headers/.success_fetching_source:
 	rm -rf vendor/linux_headers
 	mkdir -p vendor/linux_headers

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
-Bedrock Linux Userland
+Rolling Release Of Kreyrock Linux Userland
 ======================
 
-Bedrock Linux is a Linux distribution composed of user-selected components from
-various other Linux distributions.  For example, with Bedrock one may use the
+Do you have an issue? Then go fuck yourself with it! Make Merge Request like a real man or use Original Fork (https://github.com/bedrocklinux/bedrocklinux-userland) this ain't no noob distro for babysitting
+
+Kreyrock Linux is a Linux distribution composed of user-selected components from
+various other Linux distributions.  For example, with Kreyrock one may use the
 installation process from one distribution, the init from another, a window
-manager from a third, and a web browser from a fourth.  Bedrock strives to make
+manager from a third, and a web browser from a fourth.  Kreyrock strives to make
 these components work together as transparently as possible such that for
 day-to-day operations it is not readily evident that the various components
 were originally intended for disparate distributions.
 
-This repository contains all the userland code for a Bedrock Linux system.  It
-can create a script which may be used to install or update a Bedrock Linux
+This repository contains all the userland code for a Kreyrock Linux system.  It
+can create a script which may be used to install or update a Kreyrock Linux
 system.
 
 Building the installer/updater
@@ -48,15 +50,15 @@ projects:
   jobs.
 - You may set `CFLAGS` to pass flags to the C compiler such as `-Os` and
   `-march=native`.
-	- Bedrock's components *must* be statically compiled.  The build system
+	- Kreyrock's components *must* be statically compiled.  The build system
 	  sets `-static` in various places.  Do not set `-dynamic` or otherwise
 	  try to change away from a static build.
 
 This will produce a script such as:
 
-	bedrock-linux-0.7-x86_64.sh
+	Kreyrock-linux-0.7-x86_64.sh
 
-which may be used to install or update a Bedrock Linux system.
+which may be used to install or update a Kreyrock Linux system.
 
 Installation
 
@@ -64,14 +66,14 @@ Installation
 	- Select a filesystem which supports extended filesystem attributes.
 - Setup users, networking, etc as one would typically do.
 - Reboot into the fresh install.
-- Get the `bedrock-linux-<version>-<arch>.sh` script onto the system, either by
+- Get the `Kreyrock-linux-<version>-<arch>.sh` script onto the system, either by
   building it locally or getting a pre-built version from elsewhere.
 - Run the script as root with the `--hijack` flag.
 - Follow the prompts.
 - Reboot.  Re-select the new install at any bootloader prompt.
-- You're now running Bedrock Linux, but with only the initial install's files.
-  To leverage Bedrock's features, we need other distribution's files as well.
-- Run `brl fetch --list` to see the various distributions which Bedrock knows
+- You're now running Kreyrock Linux, but with only the initial install's files.
+  To leverage Kreyrock's features, we need other distribution's files as well.
+- Run `brl fetch --list` to see the various distributions which Kreyrock knows
   how to fetch.
 - As root, run `brl fetch <distros>` to acquire upstream distribution files.
 	- If this fails, you may need to manually look up release and mirror
@@ -81,9 +83,9 @@ Installation
 Basic usage
 -----------
 
-A Bedrock Linux system is composed of "strata".  These are collections of
+A Kreyrock Linux system is composed of "strata".  These are collections of
 interrelated files.  These are often, but not always, one-to-one with other,
-traditional Linux distributions.  Bedrock integrates these strata together,
+traditional Linux distributions.  Kreyrock integrates these strata together,
 creating a single, largely cohesive system with desirable features from other
 distributions.
 
@@ -100,21 +102,21 @@ To acquire new strata, run (as root):
 	# brl fetch <distros>
 
 Once that has completed, you may run commands from the new strata.  For
-example, the following series of commands make sense on a Bedrock system:
+example, the following series of commands make sense on a Kreyrock system:
 
 	$ sudo brl fetch arch debian
 	$ sudo pacman -S mupdf && sudo apt install texlive
 	$ man pdflatex
 	$ pdflatex preexisting-file.tex && mupdf preexisting-file.pdf
 
-Bedrock's integration is not limited to the command line.  For example,
+Kreyrock's integration is not limited to the command line.  For example,
 graphical application menus or launchers will automatically pick up
 applications across strata, and Xorg fonts installed from one stratum will be
 picked up in an X11 graphical application from another stratum.
 
-If there are multiple instances of an executable, Bedrock will select one by
+If there are multiple instances of an executable, Kreyrock will select one by
 default in a given context.  If there are hints it can pick up on for which one
-to use, it is normally correct.  `brl which` can be used to query which Bedrock
+to use, it is normally correct.  `brl which` can be used to query which Kreyrock
 will select in a given context.  For example:
 
 	$ # arch, debian, and centos are installed.
@@ -174,24 +176,24 @@ same file.  For example, `/home`.  Such shared files are referred to as
 	arch
 
 If you would like to specify which non-global file to read or write, prefix
-`/bedrock/strata/<stratum>/` to its path.
+`/Kreyrock/strata/<stratum>/` to its path.
 
-	$ brl which --filepath /bedrock/strata/debian/etc/apt/sources.list
+	$ brl which --filepath /Kreyrock/strata/debian/etc/apt/sources.list
 	debian
-	$ brl which --filepath /bedrock/strata/ubuntu/etc/apt/sources.list
+	$ brl which --filepath /Kreyrock/strata/ubuntu/etc/apt/sources.list
 	ubuntu
 	$ # edit debian's sources.list with ubuntu's vi
-	$ strat ubuntu vi /bedrock/strata/debian/etc/apt/sources.list
+	$ strat ubuntu vi /Kreyrock/strata/debian/etc/apt/sources.list
 
 `brl` provides much more functionality which can be read from `brl --help`.
 
-A concrete list of everything Bedrock can integrate, work-arounds for known
-limitations, and other useful information may be found at bedrocklinux.org.
+A concrete list of everything Kreyrock can integrate, work-arounds for known
+limitations, and other useful information may be found at Kreyrocklinux.org.
 
 Hacking
 -------
 
-To sanity check your work (e.g. before upstream changes to Bedrock Linux),
+To sanity check your work (e.g. before upstream changes to Kreyrock Linux),
 install:
 
 - shellcheck
@@ -220,9 +222,6 @@ to run various sanity checks against the code base.
 Where To Get Help
 -----------------
 
-- Website: https://bedrocklinux.org
-- IRC: `#bedrock` on irc.freenode.net
-	- https://webchat.freenode.net/?channels=bedrock
-- Forums: http://www.linuxquestions.org/questions/bedrock-linux-118
-- Reddit: http://reddit.com/r/bedrocklinux
-- Github: https://github.com/bedrocklinux
+- Wiki: http://kreyrock.rixotstudio.cz/wiki/Main_Page
+- IRC: `#Bedrock-kreyren` on irc.freenode.net
+	- https://webchat.freenode.net/?channels=Kreyrock

--- a/src/slash-bedrock/etc/bedrock.conf
+++ b/src/slash-bedrock/etc/bedrock.conf
@@ -87,7 +87,7 @@ paths = /sbin/init, /sbin/fallback-init, /sbin/myinit, /sbin/ninit, /sbin/openrc
 # mounted into one of these directories, that new mount point
 # is also global.
 #
-share = /boot, /dev, /home, /lib/modules, /media, /mnt, /proc, /root, /run, /sys, /tmp, /var/tmp
+share = /boot, /dev, /home, /lib/modules, /media, /mnt, /proc, /root, /sys, /tmp, /var/tmp
 
 #
 # Another list of directories which should be global.  Anything mounted in them


### PR DESCRIPTION
Remove `/run` from global files since it's causing breakage on debian and exherbo.

To reproduce get openrc from gentoo and try to install `mariadb-server` on debian-buster with systemd and try to remove it.