### PR TITLE
Fix typo in brl-disable

### DIFF
--- a/src/slash-bedrock/libexec/brl-disable
+++ b/src/slash-bedrock/libexec/brl-disable
@@ -42,7 +42,7 @@ lock
 
 for alias in "${@}"; do
 	if ! is_stratum_or_alias "${alias}"; then
-		abort "No stratum or alias called \"${stratum}\"."
+		abort "No stratum or alias called \"${alias}\"."
 	elif ! stratum="$(deref "${alias}")"; then
 		abort "Unable to dereference \"${alias}\"."
 	elif is_init "${stratum}"; then


### PR DESCRIPTION
Because of an incorrect variable name, brl-disable has this output if a stratum doesn't exist:
```
/bedrock/libexec/brl-disable: line 45: stratum: parameter not set
ERROR: Unexpected error occurred.
```