### PR TITLE
_brl: Fix brl-strat command completion

### DIFF
--- a/src/slash-bedrock/share/zsh/completion/_brl
+++ b/src/slash-bedrock/share/zsh/completion/_brl
@@ -67,6 +67,7 @@ fi
 case "${words[2]}" in
 "strat")
 	args+=('2:brl subcommand:_brl_strat')
+	args+=('*::brl subcommand:_normal')
 	;;
 "list")
 	args+=('(-e --enabled-strata)'{-e,--enabled-strata}'[list enabled strata]')


### PR DESCRIPTION
`brl strat` had an issue where it wouldn't complete after the third argument. This allows it to complete correctly after that.