### PR TITLE
common-code: Ensure color_priority is always set

### DIFF
--- a/src/slash-bedrock/share/common-code
+++ b/src/slash-bedrock/share/common-code
@@ -1689,6 +1689,7 @@ if "${brl_color}"; then
 	export color_norm='\033[0m'
 else
 	export color_alert=''
+	export color_priority=''
 	export color_warn=''
 	export color_okay=''
 	export color_strat=''


### PR DESCRIPTION
Previously, it was not set if `brl_color` was false. This breaks the installer when either a) its stdout is not a tty or b) `miscellaneous.color` is not set to true.