### PR TITLE
Add locale support for Gentoo strat installer

### DIFF
--- a/src/slash-bedrock/share/brl-fetch/distros/gentoo
+++ b/src/slash-bedrock/share/brl-fetch/distros/gentoo
@@ -111,7 +111,6 @@ fetch() {
 	cat>>${target_dir}/etc/locale.gen<<EOF
 	en_US ISO-8859-1
 	en_US.UTF-8 UTF-8
-	C.UTF-8 UTF-8
 	EOF
 	chroot "${target_dir}" locale-gen
 	chroot "${target_dir}" eselect locale set 5

--- a/src/slash-bedrock/share/brl-fetch/distros/gentoo
+++ b/src/slash-bedrock/share/brl-fetch/distros/gentoo
@@ -107,4 +107,12 @@ fetch() {
 	mkdir -p "${target_dir}/etc/portage/repos.conf"
 	cp "${target_dir}/usr/share/portage/config/repos.conf" "${target_dir}/etc/portage/repos.conf/gentoo.conf"
 	LC_ALL=C chroot "${target_dir}" emerge-webrsync
+	echo "Defaulting to en_US ISO-8859-1 and en_US-UTF-8 UTF-8"
+	cat>>${target_dir}/etc/locale.gen<<EOF
+	en_US ISO-8859-1
+	en_US.UTF-8 UTF-8
+	C.UTF-8 UTF-8
+	EOF
+	chroot "${target_dir}" locale-gen
+	chroot "${target_dir}" eselect locale set 5
 }


### PR DESCRIPTION
The Gentoo installer does not support locales very well - it seems to not be setting `/etc/locale.gen` very well. This PR adds support for a sexy `locale.gen` file, supporting `en_US ISO-8859-1`, `en_US.UTF-8 UTF-8`, and `C.UTF-8 UTF-8`. 

Fixes #204 