### PR TITLE
Minor feature: Add -a/--all option to `brl which` to list all strata that provide a given binary

### DIFF
--- a/src/slash-bedrock/libexec/brl-which
+++ b/src/slash-bedrock/libexec/brl-which
@@ -24,6 +24,7 @@ Options:
   ${color_cmd}-f${color_norm}, ${color_cmd}--file      ${color_norm}which ${color_term}stratum${color_norm} provides a given file path
   ${color_cmd}-p${color_norm}, ${color_cmd}--pid       ${color_norm}which ${color_term}stratum${color_norm} provides a given process ID
   ${color_cmd}-x${color_norm}, ${color_cmd}--xwindow   ${color_norm}which ${color_term}stratum${color_norm} provides a given X11 window (requires xprop)
+  ${color_cmd}-a${color_norm}, ${color_cmd}--all       ${color_norm}search in all ${color_term}strata${color_norm} (files and binaries only)
   ${color_cmd}-h${color_norm}, ${color_cmd}--help      ${color_norm}print this message
 
 Guessing reasoning for ${color_sub}<blank>${color_norm} based on identifier:
@@ -67,6 +68,19 @@ which_bin() {
 	done
 }
 
+which_bin_all() (
+	min_args "${#}" "1"
+
+	while [ -n "${1:-}" ]; do
+		for stratum in $(list_strata); do
+			if path="$(strat -r "${stratum}" /bedrock/libexec/busybox which "$1" 2>/dev/null)"; then
+				which_file "/bedrock/strata/${stratum}/${path}"
+			fi
+		done
+		shift
+	done
+)
+
 which_file() {
 	while [ -n "${1:-}" ]; do
 		if ! [ -e "${1}" ]; then
@@ -89,6 +103,19 @@ which_file() {
 		shift
 	done
 }
+
+which_file_all() (
+	min_args "${#}" "1"
+
+	while [ -n "${1:-}" ]; do
+		for stratum in $(list_strata); do
+			if [ -e "/bedrock/strata/${stratum}/$1" ]; then
+				which_file "/bedrock/strata/${stratum}/$1"
+			fi
+		done
+		shift
+	done
+)
 
 which_pid() {
 	while [ -n "${1:-}" ]; do
@@ -135,30 +162,12 @@ which_xwindow() {
 	fi
 }
 
-handle_help "${@:-}"
+which_auto() {
+	if [ "${#}" -eq 0 ]; then
+		which_current
+		return
+	fi
 
-case "${1:-}" in
-"-c" | "--current" | "")
-	[ -n "${1:-}" ] && shift
-	which_current "${@}"
-	;;
-"-b" | "--bin")
-	shift
-	which_bin "${@}"
-	;;
-"-f" | "--file")
-	shift
-	which_file "${@}"
-	;;
-"-p" | "--pid")
-	shift
-	which_pid "${@}"
-	;;
-"-x" | "--xwindow")
-	shift
-	which_xwindow
-	;;
-*)
 	while [ -n "${1:-}" ]; do
 		if echo "${1}" | grep -q '^[0-9][0-9]*$'; then
 			which_pid "${1}"
@@ -169,7 +178,80 @@ case "${1:-}" in
 		fi
 		shift
 	done
-	;;
-esac
+}
+
+which_auto_all() {
+	min_args "${#}" "1"
+
+	while [ -n "${1:-}" ]; do
+		if echo "${1}" | grep -q '/'; then
+			which_file_all "${1}"
+		else
+			which_bin_all "${1}"
+		fi
+		shift
+	done
+}
+
+handle_help "${@:-}"
+
+OPTL="all,bin,file,current,pid,xwindow"
+OPTO="abcfpx"
+eval set -- "$(getopt -q -l "${OPTL}" -- "${OPTO}" "${@}")" || true
+
+list_all=false
+list_type=auto
+
+while [ -n "${1:-}" ]; do
+	case "${1:-}" in
+	"-c" | "--current")
+		shift
+		list_type=current
+		;;
+	"-b" | "--bin")
+		shift
+		list_type=bin
+		;;
+	"-a" | "--all")
+		shift
+		list_all=true
+		;;
+	"-f" | "--file")
+		shift
+		list_type=file
+		;;
+	"-p" | "--pid")
+		shift
+		list_type=pid
+		;;
+	"-x" | "--xwindow")
+		shift
+		list_type=xwindow
+		;;
+	--)
+		shift
+		break
+		;;
+	-*)
+		abort "Unrecognized argument: ${1}"
+		;;
+	*)
+		break
+		;;
+	esac
+done
+
+if [ "${list_all}" = true ]; then
+	case "${list_type}" in
+		auto|file|bin)
+			list_type="${list_type}_all"
+			;;
+		*)
+			abort "-a/--all can only be used with -f/--file or -b/--bin"
+			;;
+	esac
+fi
+
+which_${list_type} "$@"
 
 exit_success

--- a/src/slash-bedrock/share/bash/completion/brl
+++ b/src/slash-bedrock/share/bash/completion/brl
@@ -87,6 +87,7 @@ _brl() {
 			opts="${opts} $(_brl_unused_all "-f --file" "${COMP_WORDS[@]}")"
 			opts="${opts} $(_brl_unused_all "-p --pid" "${COMP_WORDS[@]}")"
 			opts="${opts} $(_brl_unused_all "-x --xwindow" "${COMP_WORDS[@]}")"
+			opts="${opts} $(_brl_unused_all "-a --all" "${COMP_WORDS[@]}")"
 		fi
 		case "${COMP_WORDS[2]}" in
 		"-c" | "--current") ;;

--- a/src/slash-bedrock/share/fish/completion/brl.fish
+++ b/src/slash-bedrock/share/fish/completion/brl.fish
@@ -83,6 +83,8 @@ complete -f -c brl -n '_brl_arg_is 2 which; and _brl_argnum 2' -o 'p' -d 'which 
 complete -f -c brl -n '_brl_arg_is 2 which; and _brl_argnum 2' -l 'pid' -d 'which stratum provides a given process ID'
 complete -f -c brl -n '_brl_arg_is 2 which; and _brl_argnum 2' -o 'x' -d 'which stratum provides a given process ID'
 complete -f -c brl -n '_brl_arg_is 2 which; and _brl_argnum 2' -l 'xwindow' -d 'which stratum provides a given X11 window'
+complete -f -c brl -n '_brl_arg_is 2 which; and _brl_argnum 2' -o 'a' -d 'search in all strata (files and binaries only)'
+complete -f -c brl -n '_brl_arg_is 2 which; and _brl_argnum 2' -l 'all' -d 'search in all strata (files and binaries only)'
 complete -f -c brl -n '_brl_arg_is 2 which; and _brl_arg_is 3 -b' -a '(_brl_which_bin)' -d 'binary'
 complete -f -c brl -n '_brl_arg_is 2 which; and _brl_arg_is 3 --bin' -a '(_brl_which_bin)' -d 'binary'
 complete -f -c brl -n '_brl_arg_is 2 which; and _brl_arg_is 3 -f' -a '(__fish_complete_path)' -d 'file'

--- a/src/slash-bedrock/share/zsh/completion/_brl
+++ b/src/slash-bedrock/share/zsh/completion/_brl
@@ -84,6 +84,7 @@ case "${words[2]}" in
 		args+=('(-f --file)'{-f,--file}'[which stratum provides a given file path]')
 		args+=('(-p --pid)'{-p,--pid}'[which stratum provides a given process ID]')
 		args+=('(-x --xwindow)'{-x,--xwindow}'[which stratum provides a given X11 window]')
+		args+=('(-a --all)'{-a,--all}'[search in all strata (files and binaries only)]')
 	fi
 	case "${words[3]}" in
 	"-c"|"--current")


### PR DESCRIPTION
## Rationale

Sometimes, when on a Bedrock system, I find myself wondering "which strata do I have X installed in?" What I'd like is a combination of the functionality of `brl which -b` (which prints the stratum that provides a given binary) and `which -a` (with GNU coreutils, this prints all the locations in which the given program can be found). I could probably implement this with a quick one-liner using `strat -r` and `which`, but to me this feels like a missing feature.

In a nutshell, here's what I'm aiming for:
```
$ brl which -a xbps-install
void
void-musl
```

This PR adds a `-a`/`--all` option to `brl which` which does this.

## Notes

1. This is mostly a proof-of-concept. I'm not sure if it will work in all scenarios, and I'm happy to completely rewrite it if necessary to fix bugs or make it follow better practice. I'm not in any rush to get this merged; this is just something I'd kind of like to see eventually that I think other people would find useful too.
2. There's an argument to be made that this should also work like `which_file` if any of the arguments contain a `/`. I can implement that too.
3. The interface might need changes; right now if multiple arguments are passed it's unclear which strata names correspond to which arguments.