### PR TITLE
pmm: pacman,yay: Fix which-packages-provide-file

### DIFF
--- a/src/slash-bedrock/share/pmm/package_managers/pacman
+++ b/src/slash-bedrock/share/pmm/package_managers/pacman
@@ -126,7 +126,8 @@ implementations["pacman", "search-for-package-by-all"]    = "strat -r ${stratum}
 implementations["pacman", "which-package-owns-file"]      = "strat -r ${stratum} pacman -Qo ${items} | awk '{print$(NF-1)}'"
 implementations["pacman", "which-packages-provide-file"]  = "strat -r ${stratum} pacman -F ${items} |\
 	awk '/^[^ ]/ {\
-		split($(NF-1), a, \"/\");\
+		split($1, a, \"/\");\
+	} /^[ ]/ {\
 		print a[2]\"\t/\"$1\
 	}'"
 

--- a/src/slash-bedrock/share/pmm/package_managers/yay
+++ b/src/slash-bedrock/share/pmm/package_managers/yay
@@ -132,7 +132,8 @@ implementations["yay", "search-for-package-by-all"]    = "${unprivileged_user} s
 implementations["yay", "which-package-owns-file"]      = "${unprivileged_user} strat -r ${stratum} yay -Qo ${items} | awk '{print$(NF-1)}'"
 implementations["yay", "which-packages-provide-file"]  = "${unprivileged_user} strat -r ${stratum} yay -F ${items} |\
 	awk '/^[^ ]/ {\
-		split($(NF-1), a, \"/\");\
+		split($1, a, \"/\");\
+	} /^[ ]/ {\
 		print a[2]\"\t/\"$1\
 	}'"
 


### PR DESCRIPTION
Fixes broken implementation.

Quick question before you merge:
pacman, Line 129 and yay, line 135
`split($(NF-1), a, \"/\");\`
You used `$(NF-1)` to get the second from the last field. I changed this to $1 as sometimes "[installed]" is included as an extra field, making `$(NF-1)` unreliable. Heres an example problematic output:
```sh
$ pacman -F zsh
extra/zsh 5.8-1 [installed]
    usr/bin/zsh
community/grunt-cli 1.3.2-2
    usr/lib/node_modules/grunt-cli/completion/zsh
...
```
Before we continue with `$1`, is there a reason you chose `$(NF-1)`? Is there sometimes an extra field before the package name?