### PR TITLE
Restrict Firejail binaries by default

### DIFF
--- a/src/slash-bedrock/etc/bedrock.conf
+++ b/src/slash-bedrock/etc/bedrock.conf
@@ -335,7 +335,7 @@ SUFFIX:fpath = /bedrock/cross/zsh-completion
 #
 # List any commands you would like restricted here.
 #
-restrict = apt-key, cave, debuild, dpkg-buildpackage, gdb, git, kiss, makepkg, pkgmk, prt-get, rpmbuild
+restrict = apt-key, cave, debuild, dpkg-buildpackage, firecfg, firejail, firetools, gdb, git, kiss, makepkg, pkgmk, prt-get, rpmbuild
 
 [cross]
 #
@@ -452,6 +452,9 @@ pin/bin/apt-key           = local:$PATH/apt-key
 pin/bin/cave              = local:$PATH/cave
 pin/bin/debuild           = local:$PATH/debuild
 pin/bin/dpkg-buildpackage = local:$PATH/dpkg-buildpackage
+pin/bin/firecfg           = local:$PATH/firecfg
+pin/bin/firejail          = local:$PATH/firejail
+pin/bin/firetools         = local:$PATH/firetools
 pin/bin/gdb               = local:$PATH/gdb
 pin/bin/git               = local:$PATH/git
 pin/bin/kiss              = local:$PATH/kiss


### PR DESCRIPTION
Addresses #219.

I took the liberty of adding a few more binaries that could cause further issues and shouldn't really be accessible across stratums, but I specifically left out `firejail-ui`, as it appears to be a GUI wrapper.