### PR TITLE
brl-fetch: Support color when listing fetchable strata

### DIFF
--- a/src/slash-bedrock/libexec/brl-fetch
+++ b/src/slash-bedrock/libexec/brl-fetch
@@ -206,7 +206,7 @@ list_backends() {
 		fi
 		for arch in $(list_architectures); do
 			if [ "${arch}" = "${target_arch}" ]; then
-				basename "${backend}"
+				printf "${color_strat}%s${color_norm}\\n" "${backend##*/}"
 				break
 			fi
 		done


### PR DESCRIPTION
Adds color to `brl fetch --list` and `brl fetch -X`. Also switches from `basename ${backend}`to `${backend##*/}` which should be faster and accomplish the same thing.