### PR TITLE
common-code: Check before removing attributes

### DIFF
--- a/src/slash-bedrock/share/common-code
+++ b/src/slash-bedrock/share/common-code
@@ -511,7 +511,9 @@ set_attr() {
 rm_attr() {
 	file="${1}"
 	attr="${2}"
-	/bedrock/libexec/setfattr -x "user.bedrock.${attr}" "${file}"
+	if has_attr "${file}" "${attr}"; then
+		/bedrock/libexec/setfattr -x "user.bedrock.${attr}" "${file}"
+	fi
 }
 
 # Checks if argument is an existing stratum


### PR DESCRIPTION
Currently, if you attempt to hide an already hidden stratum you'll run into an error. This simply adds a check which makes sure the attribute you're attempting to remove exists before removing it allowing brl hide to work on already hidden strata.