### PR TITLE
Add Carbs Linux

### DIFF
--- a/src/installer/installer.sh
+++ b/src/installer/installer.sh
@@ -6,7 +6,7 @@
 #      modify it under the terms of the GNU General Public License
 #      version 2 as published by the Free Software Foundation.
 #
-# Copyright (c) 2018-2020 Daniel Thau <danthau@bedrocklinux.org>
+# Copyright (c) 2018-2021 Daniel Thau <danthau@bedrocklinux.org>
 #
 # Installs or updates a Bedrock Linux system.
 
@@ -119,6 +119,9 @@ Please type \"Not reversible!\" without quotes at the prompt to continue:
 		abort "grub-mkrelpath/grub2-mkrelpath --relative does not support bind-mounts on /boot.  Continuing may break the bootloader on a kernel update.  This is a known Bedrock issue with OpenSUSE+btrfs/GRUB."
 	elif [ -r /boot/grub/grub.cfg ] && { grep -q 'subvol=' /boot/grub/grub.cfg || grep -q 'ZFS=' /boot/grub/grub.cfg; }; then
 		abort '`subvol=` or `ZFS=` detected in `/boot/grub/grub.cfg` indicating GRUB usage on either BTRFS or ZFS.  GRUB can get confused when updating this content on Bedrock which results in a non-booting system.  Either use another filesystem or another bootloader.'
+	elif grep -qi 'btrfs' '/proc/mounts' && find /boot -iname "*grub*" >/dev/null 2>&; then
+		# Some users have reported getting past above two checks.  This additional check is prone to false-positive, but it's better to be conservative here.
+		abort 'Detected BTRFS mount and GRUB reference in /boot.  GRUB can get confused when updating its configuration in this scenario.  Either use another filesystem or another bootloader.'
 	elif [ -e /bedrock/ ]; then
 		# Prefer this check at end of sanity check list so other sanity
 		# checks can be tested directly on a Bedrock system.

--- a/src/slash-bedrock/share/brl-fetch/distros/carbs
+++ b/src/slash-bedrock/share/brl-fetch/distros/carbs
@@ -1,0 +1,60 @@
+#!/bedrock/libexec/busybox sh
+#
+# Carbs Linux bootstrap support
+#
+#      This program is free software; you can redistribute it and/or
+#      modify it under the terms of the GNU General Public License
+#      version 2 as published by the Free Software Foundation.
+#
+# Copyright (c) 2019-2020 Daniel Thau <danthau@bedrocklinux.org>
+#
+
+# shellcheck source=src/slash-bedrock/libexec/brl-fetch
+. /bedrock/share/common-code
+trap 'fetch_abort "Unexpected error occurred."' EXIT
+
+check_supported() {
+	false
+}
+
+speed_test_url() {
+	echo "sha256sums.txt"
+}
+
+list_mirrors() {
+	echo 'https://dl.carbslinux.org/releases/'
+}
+
+brl_arch_to_distro() {
+	case "${1}" in
+	"x86_64") echo "x86_64" ;;
+	"i686") echo "i686" ;;
+	*) abort "brl does not know how to translate arch \"${1}\" to ${distro} format" ;;
+	esac
+}
+
+list_architectures() {
+	cat <<EOF
+x86_64
+i686
+EOF
+}
+
+default_release() {
+	echo "rolling"
+}
+
+list_releases() {
+	echo "rolling"
+}
+
+fetch() {
+	prefix="https://dl.carbslinux.org/releases"
+	step "Downloading bootstrap software"
+	download "${prefix}/${target_arch}/carbs-rootfs.tar.xz.sha256" "${bootstrap_dir}/checksum"
+	bootstrap_checksum="$(awk '{print$1}' "${bootstrap_dir}/checksum")"
+	checksum_download "${cache}/bootstrap.tar.xz" "sha256sum" "${bootstrap_checksum}" "${prefix}/${target_arch}/carbs-rootfs.tar.xz"
+
+	step "Extracting bootstrap software"
+	tar -xv -f "${cache}/bootstrap.tar.xz" -C "${target_dir}" | awk 'NR%100==0' | progress_unknown
+}

--- a/src/slash-bedrock/share/brl-fetch/distros/centos
+++ b/src/slash-bedrock/share/brl-fetch/distros/centos
@@ -99,11 +99,11 @@ determine_package_manager() {
 }
 
 bootstrap_deps() {
-	echo "${package_manager} rpm centos-release filesystem centos-gpg-keys shadow-utils"
+	echo "${package_manager} rpm centos-release filesystem shadow-utils"
 
 	# At the time of writing, CentOS 8-stream no longer includes repos as a dependency of the package manager
 	if echo "${target_release}" | grep -q stream; then
-		echo "centos-stream-repos"
+		echo "centos-stream-repos centos-gpg-keys"
 	fi
 }
 

--- a/src/slash-bedrock/share/brl-fetch/distros/fedora
+++ b/src/slash-bedrock/share/brl-fetch/distros/fedora
@@ -59,10 +59,11 @@ default_release() {
 }
 
 list_releases() {
-	download -q 'https://download-ib01.fedoraproject.org/pub/fedora-secondary/releases/' - |
+	download -q 'https://dl.fedoraproject.org/pub/fedora/linux/releases/' - |
 		list_links |
 		grep '^[0-9][0-9]*/$' |
-		sed 's,/$,,'
+		sed 's,/$,,' |
+		sort -n
 }
 
 determine_package_manager() {

--- a/src/slash-bedrock/share/brl-fetch/distros/gentoo
+++ b/src/slash-bedrock/share/brl-fetch/distros/gentoo
@@ -6,7 +6,7 @@
 #      modify it under the terms of the GNU General Public License
 #      version 2 as published by the Free Software Foundation.
 #
-# Copyright (c) 2016-2020 Daniel Thau <danthau@bedrocklinux.org>
+# Copyright (c) 2016-2021 Daniel Thau <danthau@bedrocklinux.org>
 #
 
 # shellcheck source=src/slash-bedrock/libexec/brl-fetch
@@ -68,6 +68,12 @@ list_releases() {
 }
 
 fetch() {
+	# TODO: Gentoo apprently removed minimal Stage 3, now requires an init.
+	# Defaulting to openrc.  In Bedrock 0.8.0 when `brl fetch --flavor` is
+	# available make deskop vs hardened vs musl, openrc vs systemd,
+	# flavors.
+	flavor="desktop-openrc"
+
 	step "Finding bootstrap software"
 	groups="$(download -q "${target_mirror}/releases/" - |
 		list_links |
@@ -76,7 +82,7 @@ fetch() {
 	group="$(for group in ${groups}; do
 		if download -q "${target_mirror}/releases/${group}/autobuilds/" - |
 			list_links |
-			grep "^current-stage3-${distro_arch}/$" >/dev/null; then
+			grep "^current-stage3-${distro_arch}-${flavor}/$" >/dev/null; then
 			echo "${group}"
 			break
 		fi
@@ -86,7 +92,7 @@ fetch() {
 	fi
 
 	step "Downloading bootstrap software"
-	bootstrap_url="$(find_link "${target_mirror}/releases/${group}/autobuilds/current-stage3-${distro_arch}/" "^stage3-${distro_arch}-[^.]*[.]tar[.]\(xz\|bz2\)$")"
+	bootstrap_url="$(find_link "${target_mirror}/releases/${group}/autobuilds/current-stage3-${distro_arch}-${flavor}/" "^stage3-${distro_arch}-[^.]*[.]tar[.]\(xz\|bz2\)$")"
 	bootstrap_name="$(echo "${bootstrap_url}" | sed 's,^.*/,,')"
 	download "${bootstrap_url}.DIGESTS" "${bootstrap_dir}/checksum"
 	bootstrap_checksum="$(awk -v"name=${bootstrap_name}" '/^# .* HASH$/ {hash=$2;next} hash == "SHA512" && $2 == name {print$1;exit}' "${bootstrap_dir}/checksum")"


### PR DESCRIPTION
Added Carbs Linux support. Carbs is a fork of KISS, so the brl-fetch file for it is a highly modified version of the KISS one. (is still being tested)

EDIT: Done testing, working so far, although it may need to be restricted, which I have not done yet. Like I said, Carbs is a fork of KISS, and both (may) find executables on the fly.