### PR TITLE
brl-fetch: add development releases of fedora

### DIFF
--- a/src/slash-bedrock/share/brl-fetch/distros/fedora
+++ b/src/slash-bedrock/share/brl-fetch/distros/fedora
@@ -18,7 +18,14 @@ check_supported() {
 }
 
 speed_test_url() {
-	echo "releases/${target_release}/Everything/${distro_arch}/os/repodata/repomd.xml"
+
+	if [[ $(list_development | tr -d '[:space:]') == *${target_release}* ]]; then
+		url_type="development"
+	else
+		url_type="releases"
+	fi
+	
+	echo "${url_type}/${target_release}/Everything/${distro_arch}/os/repodata/repomd.xml"
 }
 
 list_mirrors() {
@@ -53,17 +60,40 @@ EOF
 }
 
 default_release() {
-	list_releases |
+	list_release |
 		sort -n |
 		tail -n1
 }
 
 list_releases() {
+
+	echo
+	echo "Release"
+	echo "---------------------"
+
+	list_release
+
+	echo
+	echo "Development"
+	echo "---------------------"
+	
+	list_development
+}
+
+list_release() {
 	download -q 'https://dl.fedoraproject.org/pub/fedora/linux/releases/' - |
 		list_links |
 		grep '^[0-9][0-9]*/$' |
 		sed 's,/$,,' |
 		sort -n
+}
+
+list_development() {
+	download -q 'https://dl.fedoraproject.org/pub/fedora/linux/development/' - |
+	list_links |
+	sed 's,/$,,' |
+	grep -v "/" |
+	sort -n
 }
 
 determine_package_manager() {
@@ -78,8 +108,14 @@ bootstrap_deps() {
 	echo "${package_manager} rpm fedora-release filesystem fedora-gpg-keys"
 }
 
-fetch() {
-	suffix="releases/${target_release}/Everything/${distro_arch}/os"
+fetch() {	
+	if [[ $(list_development | tr -d '[:space:]') == *${target_release}* ]]; then
+		url_type="development"
+	else
+		url_type="releases"
+	fi
+	
+	suffix="${url_type}/${target_release}/Everything/${distro_arch}/os"
 
 	step "Downloading package information database"
 	url="$(find_link "${target_mirror}/${suffix}/repodata/" "primary.xml.gz")"

--- a/src/slash-bedrock/share/brl-fetch/distros/fedora
+++ b/src/slash-bedrock/share/brl-fetch/distros/fedora
@@ -68,24 +68,24 @@ default_release() {
 }
 
 list_releases() {
-	list_release
-	list_development
+	(
+		list_release
+		list_development
+	) | sort -n
 }
 
 list_release() {
 	download -q 'https://dl.fedoraproject.org/pub/fedora/linux/releases/' - |
 		list_links |
 		grep '^[0-9][0-9]*/$' |
-		sed 's,/$,,' |
-		sort -n
+		sed 's,/$,,'
 }
 
 list_development() {
 	download -q 'https://dl.fedoraproject.org/pub/fedora/linux/development/' - |
 	list_links |
 	sed 's,/$,,' |
-	grep -v "/" |
-	sort -n
+	grep -v "/"
 }
 
 determine_package_manager() {

--- a/src/slash-bedrock/share/brl-fetch/distros/fedora
+++ b/src/slash-bedrock/share/brl-fetch/distros/fedora
@@ -18,7 +18,7 @@ check_supported() {
 }
 
 set_url_type() {
-	if [[ $(list_development | tr -d '[:space:]') == *${target_release}* ]]; then
+	if ! list_development | awk -v"x=${target_release}" '$0 == x {exit 1}'; then
 		url_type="development"
 	else
 		url_type="releases"

--- a/src/slash-bedrock/share/brl-fetch/distros/fedora
+++ b/src/slash-bedrock/share/brl-fetch/distros/fedora
@@ -17,14 +17,16 @@ check_supported() {
 	true
 }
 
-speed_test_url() {
-
+set_url_type() {
 	if [[ $(list_development | tr -d '[:space:]') == *${target_release}* ]]; then
 		url_type="development"
 	else
 		url_type="releases"
 	fi
-	
+}
+
+speed_test_url() {
+	set_url_type
 	echo "${url_type}/${target_release}/Everything/${distro_arch}/os/repodata/repomd.xml"
 }
 
@@ -99,11 +101,7 @@ bootstrap_deps() {
 }
 
 fetch() {	
-	if [[ $(list_development | tr -d '[:space:]') == *${target_release}* ]]; then
-		url_type="development"
-	else
-		url_type="releases"
-	fi
+	set_url_type
 	
 	suffix="${url_type}/${target_release}/Everything/${distro_arch}/os"
 

--- a/src/slash-bedrock/share/brl-fetch/distros/fedora
+++ b/src/slash-bedrock/share/brl-fetch/distros/fedora
@@ -178,7 +178,7 @@ fetch() {
 	fi
 
 	LC_ALL=C chroot "${bootstrap_dir}" rpm -i --root=/target-root --nodeps ./packages/fedora-release-*.rpm 2>/dev/null || true
-	LC_ALL=C chroot "${bootstrap_dir}" "${package_manager}" --installroot=/target-root install -y rpm-build "${package_manager}" fedora-repos
+	LC_ALL=C chroot "${bootstrap_dir}" "${package_manager}" --installroot=/target-root install -y rpm-build "${package_manager}" fedora-repos --releasever ${target_release}
 	# Need to set database timestamps for pmm due to `dnf -C` usage
 	umount -l "${bootstrap_dir}/var/cache/dnf" >/dev/null 2>&1 || true
 	umount -l "${bootstrap_dir}/var/cache/yum" >/dev/null 2>&1 || true

--- a/src/slash-bedrock/share/brl-fetch/distros/fedora
+++ b/src/slash-bedrock/share/brl-fetch/distros/fedora
@@ -66,17 +66,7 @@ default_release() {
 }
 
 list_releases() {
-
-	echo
-	echo "Release"
-	echo "---------------------"
-
 	list_release
-
-	echo
-	echo "Development"
-	echo "---------------------"
-	
 	list_development
 }
 


### PR DESCRIPTION
This PR should fix the default release being from testing issue (sorry for the 2nd pr)

I am unsure on how to show the releases, so feedback and corrections wanted there
I also hope using `tr` is alright 
And yes, fetching the fedora development releases multiple times does add on a bit of time, however it seemed to match the coding style more than using a global variable and fedora takes a while to fetch anyway (so not loads % wise)