### PR TITLE
brl-fetch: fix exherbo sum checking and update arch

### DIFF
--- a/src/slash-bedrock/share/brl-fetch/distros/exherbo
+++ b/src/slash-bedrock/share/brl-fetch/distros/exherbo
@@ -29,8 +29,8 @@ list_mirrors() {
 
 brl_arch_to_distro() {
 	case "${1}" in
+	"aarch64") echo "aarch64" ;;
 	"armv7hl") echo "armv7" ;;
-	"i686") echo "i686" ;;
 	"x86_64") echo "x86_64" ;;
 	*) abort "brl does not know how to translate arch \"${1}\" to ${distro} format" ;;
 	esac
@@ -38,8 +38,8 @@ brl_arch_to_distro() {
 
 list_architectures() {
 	cat <<EOF
+aarch64
 armv7hl
-i686
 x86_64
 EOF
 }
@@ -58,8 +58,8 @@ fetch() {
 	paludis_group=paludisbuild
 
 	case "${target_arch}" in
+	"aarch64") ex_stage="exherbo-aarch64-unknown-linux-gnueabi-current.tar.xz" ;;
 	"armv7hl") ex_stage="exherbo-armv7-unknown-linux-gnueabihf-current.tar.xz" ;;
-	"i686") ex_stage="exherbo-i686-pc-linux-gnu-current.tar.xz" ;;
 	"x86_64") ex_stage="exherbo-x86_64-pc-linux-gnu-current.tar.xz" ;;
 	esac
 	ex_checksum_fn=sha256sum

--- a/src/slash-bedrock/share/brl-fetch/distros/exherbo
+++ b/src/slash-bedrock/share/brl-fetch/distros/exherbo
@@ -62,12 +62,12 @@ fetch() {
 	"i686") ex_stage="exherbo-i686-pc-linux-gnu-current.tar.xz" ;;
 	"x86_64") ex_stage="exherbo-x86_64-pc-linux-gnu-current.tar.xz" ;;
 	esac
-	ex_checksum_fn=sha1sum
+	ex_checksum_fn=sha256sum
 
 	step "Downloading & verifying bootstrap software"
-	download "${target_mirror}"/stages/"${ex_checksum_fn}" "${bootstrap_dir}/${ex_checksum_fn}"
-	ex_sha1sum="$(awk -v"name=${ex_stage}" '/^# .* HASH$/ {hash=$1;next} $2 == name {print$1;exit}' "${bootstrap_dir}/${ex_checksum_fn}")"
-	checksum_download "${cache}/${ex_stage}" "sha1sum" "${ex_sha1sum}" "${target_mirror}"/stages/"${ex_stage}"
+	download "${target_mirror}"/stages/"${ex_stage}.${ex_checksum_fn}" "${bootstrap_dir}/${ex_stage}.${ex_checksum_fn}"
+	ex_sha256sum="$(awk -v"name=exherbo" '/^# .* HASH$/ {hash=$1;next} index($2, name) {print$1;exit}' "${bootstrap_dir}/${ex_stage}.${ex_checksum_fn}")"
+	checksum_download "${cache}/${ex_stage}" "sha256sum" "${ex_sha256sum}" "${target_mirror}"/stages/"${ex_stage}"
 
 	step "Preparing bootstrap software"
 	tar xvJp -C "${bootstrap_dir}" -f "${cache}"/"${ex_stage}" | awk 'NR%100==0' | progress_unknown

--- a/src/slash-bedrock/share/brl-fetch/distros/exherbo
+++ b/src/slash-bedrock/share/brl-fetch/distros/exherbo
@@ -20,7 +20,7 @@ check_supported() {
 }
 
 speed_test_url() {
-	echo "/stages/sha1sum"
+	echo "/index.html"
 }
 
 list_mirrors() {

--- a/src/slash-bedrock/share/brl-fetch/distros/exherbo-musl
+++ b/src/slash-bedrock/share/brl-fetch/distros/exherbo-musl
@@ -20,7 +20,7 @@ check_supported() {
 }
 
 speed_test_url() {
-	echo "/stages/sha1sum"
+	echo "/index.html"
 }
 
 list_mirrors() {

--- a/src/slash-bedrock/share/brl-fetch/distros/exherbo-musl
+++ b/src/slash-bedrock/share/brl-fetch/distros/exherbo-musl
@@ -54,12 +54,12 @@ fetch() {
 	paludis_group=paludisbuild
 
 	ex_stage="exherbo-x86_64-pc-linux-musl-current.tar.xz"
-	ex_checksum_fn=sha1sum
+	ex_checksum_fn=sha256sum
 
 	step "Downloading & verifying bootstrap software"
-	download "${target_mirror}"/stages/"${ex_checksum_fn}" "${bootstrap_dir}/${ex_checksum_fn}"
-	ex_sha1sum="$(awk -v"name=${ex_stage}" '/^# .* HASH$/ {hash=$1;next} $2 == name {print$1;exit}' "${bootstrap_dir}/${ex_checksum_fn}")"
-	checksum_download "${cache}/${ex_stage}" "sha1sum" "${ex_sha1sum}" "${target_mirror}"/stages/"${ex_stage}"
+	download "${target_mirror}"/stages/${ex_stage}."${ex_checksum_fn}" "${bootstrap_dir}/${ex_stage}.${ex_checksum_fn}"
+	ex_sha256sum="$(awk -v"name=exherbo" '/^# .* HASH$/ {hash=$1;next} index($2, name) {print$1;exit}' "${bootstrap_dir}/${ex_stage}.${ex_checksum_fn}")"
+	checksum_download "${cache}/${ex_stage}" "sha256sum" "${ex_sha256sum}" "${target_mirror}"/stages/"${ex_stage}"
 
 	step "Preparing bootstrap software"
 	tar xvJp -C "${bootstrap_dir}" -f "${cache}"/"${ex_stage}" | awk 'NR%100==0' | progress_unknown


### PR DESCRIPTION
Exherbo now provides per file sha256 checksum file.
Also some archs have been discontinued and added.

I'm also updating speed test url as the sha1sum file might disappears as it is no more used.