### PR TITLE
brl-fetch: update exherbo stages links

### DIFF
--- a/src/slash-bedrock/share/brl-fetch/distros/exherbo
+++ b/src/slash-bedrock/share/brl-fetch/distros/exherbo
@@ -58,9 +58,9 @@ fetch() {
 	paludis_group=paludisbuild
 
 	case "${target_arch}" in
-	"aarch64") ex_stage="exherbo-aarch64-unknown-linux-gnueabi-current.tar.xz" ;;
-	"armv7hl") ex_stage="exherbo-armv7-unknown-linux-gnueabihf-current.tar.xz" ;;
-	"x86_64") ex_stage="exherbo-x86_64-pc-linux-gnu-current.tar.xz" ;;
+	"aarch64") ex_stage="exherbo-aarch64-unknown-linux-gnueabi-gcc-current.tar.xz" ;;
+	"armv7hl") ex_stage="exherbo-armv7-unknown-linux-gnueabihf-gcc-current.tar.xz" ;;
+	"x86_64") ex_stage="exherbo-x86_64-pc-linux-gnu-gcc-current.tar.xz" ;;
 	esac
 	ex_checksum_fn=sha256sum
 

--- a/src/slash-bedrock/share/brl-fetch/distros/exherbo-musl
+++ b/src/slash-bedrock/share/brl-fetch/distros/exherbo-musl
@@ -53,7 +53,7 @@ fetch() {
 	paludis_user=paludisbuild
 	paludis_group=paludisbuild
 
-	ex_stage="exherbo-x86_64-pc-linux-musl-current.tar.xz"
+	ex_stage="exherbo-x86_64-pc-linux-musl-gcc-current.tar.xz"
 	ex_checksum_fn=sha256sum
 
 	step "Downloading & verifying bootstrap software"


### PR DESCRIPTION
Newest exherbo stage releases are using a new name scheme including the compiler
https://dev.exherbo.org/stages/