### PR TITLE
Remove community and galaxy repos from Arch and Artix

### DIFF
--- a/src/slash-bedrock/share/brl-fetch/distros/arch
+++ b/src/slash-bedrock/share/brl-fetch/distros/arch
@@ -77,14 +77,12 @@ fetch() {
 	step "Downloading package information database"
 	download "${target_mirror}/core/os/${distro_arch}/core.db.tar.gz" "${bootstrap_dir}/core.db.tar.gz"
 	download "${target_mirror}/extra/os/${distro_arch}/extra.db.tar.gz" "${bootstrap_dir}/extra.db.tar.gz"
-	download "${target_mirror}/community/os/${distro_arch}/community.db.tar.gz" "${bootstrap_dir}/community.db.tar.gz"
 
 	step "Decompressing package information database"
-	mkdir -p "${bootstrap_dir}/pacmandb/core" "${bootstrap_dir}/pacmandb/extra" "${bootstrap_dir}/pacmandb/community"
+	mkdir -p "${bootstrap_dir}/pacmandb/core" "${bootstrap_dir}/pacmandb/extra"
 	(
 		tar -xv -f "${bootstrap_dir}/core.db.tar.gz" -C "${bootstrap_dir}/pacmandb/core/"
 		tar -xv -f "${bootstrap_dir}/extra.db.tar.gz" -C "${bootstrap_dir}/pacmandb/extra/"
-		tar -xv -f "${bootstrap_dir}/community.db.tar.gz" -C "${bootstrap_dir}/pacmandb/community/"
 	) | awk 'NR%100==0' | progress_unknown
 
 	step "Converting distro package information database to brl format"

--- a/src/slash-bedrock/share/brl-fetch/distros/arch-32
+++ b/src/slash-bedrock/share/brl-fetch/distros/arch-32
@@ -78,14 +78,12 @@ fetch() {
 	step "Downloading package information database"
 	download "${target_mirror}/${distro_arch}/core/core.db.tar.gz" "${bootstrap_dir}/core.db.tar.gz"
 	download "${target_mirror}/${distro_arch}/extra/extra.db.tar.gz" "${bootstrap_dir}/extra.db.tar.gz"
-	download "${target_mirror}/${distro_arch}/community/community.db.tar.gz" "${bootstrap_dir}/community.db.tar.gz"
 
 	step "Decompressing package information database"
-	mkdir -p "${bootstrap_dir}/pacmandb/core" "${bootstrap_dir}/pacmandb/extra" "${bootstrap_dir}/pacmandb/community"
+	mkdir -p "${bootstrap_dir}/pacmandb/core" "${bootstrap_dir}/pacmandb/extra"
 	(
 		tar -xv -f "${bootstrap_dir}/core.db.tar.gz" -C "${bootstrap_dir}/pacmandb/core/"
 		tar -xv -f "${bootstrap_dir}/extra.db.tar.gz" -C "${bootstrap_dir}/pacmandb/extra/"
-		tar -xv -f "${bootstrap_dir}/community.db.tar.gz" -C "${bootstrap_dir}/pacmandb/community/"
 	) | awk 'NR%100==0' | progress_unknown
 
 	step "Converting distro package information database to brl format"

--- a/src/slash-bedrock/share/brl-fetch/distros/arch-arm
+++ b/src/slash-bedrock/share/brl-fetch/distros/arch-arm
@@ -87,14 +87,12 @@ fetch() {
 	step "Downloading package information database"
 	download "${target_mirror}/${distro_arch}/core/core.db.tar.gz" "${bootstrap_dir}/core.db.tar.gz"
 	download "${target_mirror}/${distro_arch}/extra/extra.db.tar.gz" "${bootstrap_dir}/extra.db.tar.gz"
-	download "${target_mirror}/${distro_arch}/community/community.db.tar.gz" "${bootstrap_dir}/community.db.tar.gz"
 
 	step "Decompressing package information database"
-	mkdir -p "${bootstrap_dir}/pacmandb/core" "${bootstrap_dir}/pacmandb/extra" "${bootstrap_dir}/pacmandb/community"
+	mkdir -p "${bootstrap_dir}/pacmandb/core" "${bootstrap_dir}/pacmandb/extra"
 	(
 		tar -xv -f "${bootstrap_dir}/core.db.tar.gz" -C "${bootstrap_dir}/pacmandb/core/"
 		tar -xv -f "${bootstrap_dir}/extra.db.tar.gz" -C "${bootstrap_dir}/pacmandb/extra/"
-		tar -xv -f "${bootstrap_dir}/community.db.tar.gz" -C "${bootstrap_dir}/pacmandb/community/"
 	) | awk 'NR%100==0' | progress_unknown
 
 	step "Converting distro package information database to brl format"

--- a/src/slash-bedrock/share/brl-fetch/distros/artix
+++ b/src/slash-bedrock/share/brl-fetch/distros/artix
@@ -76,14 +76,12 @@ fetch() {
 	step "Downloading package information database"
 	download "${target_mirror}/system/os/${distro_arch}/system.db.tar.gz" "${bootstrap_dir}/system.db.tar.gz"
 	download "${target_mirror}/world/os/${distro_arch}/world.db.tar.gz" "${bootstrap_dir}/world.db.tar.gz"
-	download "${target_mirror}/galaxy/os/${distro_arch}/galaxy.db.tar.gz" "${bootstrap_dir}/galaxy.db.tar.gz"
 
 	step "Decompressing package information database"
-	mkdir -p "${bootstrap_dir}/pacmandb/system" "${bootstrap_dir}/pacmandb/world" "${bootstrap_dir}/pacmandb/galaxy"
+	mkdir -p "${bootstrap_dir}/pacmandb/system" "${bootstrap_dir}/pacmandb/world"
 	(
 		tar -xv -f "${bootstrap_dir}/system.db.tar.gz" -C "${bootstrap_dir}/pacmandb/system/"
 		tar -xv -f "${bootstrap_dir}/world.db.tar.gz" -C "${bootstrap_dir}/pacmandb/world/"
-		tar -xv -f "${bootstrap_dir}/galaxy.db.tar.gz" -C "${bootstrap_dir}/pacmandb/galaxy/"
 	) | awk 'NR%100==0' | progress_unknown
 
 	step "Converting distro package information database to brl format"

--- a/src/slash-bedrock/share/brl-fetch/distros/artix-s6
+++ b/src/slash-bedrock/share/brl-fetch/distros/artix-s6
@@ -76,14 +76,12 @@ fetch() {
 	step "Downloading package information database"
 	download "${target_mirror}/system/os/${distro_arch}/system.db.tar.gz" "${bootstrap_dir}/system.db.tar.gz"
 	download "${target_mirror}/world/os/${distro_arch}/world.db.tar.gz" "${bootstrap_dir}/world.db.tar.gz"
-	download "${target_mirror}/galaxy/os/${distro_arch}/galaxy.db.tar.gz" "${bootstrap_dir}/galaxy.db.tar.gz"
 
 	step "Decompressing package information database"
-	mkdir -p "${bootstrap_dir}/pacmandb/system" "${bootstrap_dir}/pacmandb/world" "${bootstrap_dir}/pacmandb/galaxy"
+	mkdir -p "${bootstrap_dir}/pacmandb/system" "${bootstrap_dir}/pacmandb/world"
 	(
 		tar -xv -f "${bootstrap_dir}/system.db.tar.gz" -C "${bootstrap_dir}/pacmandb/system/"
 		tar -xv -f "${bootstrap_dir}/world.db.tar.gz" -C "${bootstrap_dir}/pacmandb/world/"
-		tar -xv -f "${bootstrap_dir}/galaxy.db.tar.gz" -C "${bootstrap_dir}/pacmandb/galaxy/"
 	) | awk 'NR%100==0' | progress_unknown
 
 	step "Converting distro package information database to brl format"


### PR DESCRIPTION
The Arch and Artix repositories were recently migrated from subversion to git. As part of the migration, Arch's community repository was merged into the extra repository. Artix followed suit by merging their galaxy repository into the world repository. This PR addresses these changes and removes the community and galaxy repository from the brl-fetch script for Arch and Artix.

Relevant announcements:
https://archlinux.org/news/git-migration-announcement/
https://archlinux.org/news/git-migration-completed/
https://artixlinux.org/news.php#Repository_changes

This PR addresses issue #287.