### PR TITLE
pmm: fix awk syntax when package caching in yay

### DIFF
--- a/src/slash-bedrock/share/pmm/package_managers/yay
+++ b/src/slash-bedrock/share/pmm/package_managers/yay
@@ -159,7 +159,7 @@ implementations["yay", "print-package-version"]              = "${unprivileged_u
 		}'"
 implementations["yay", "cache-package-db"]                   = "${unprivileged_user} strat -r ${stratum} yay -Sl |\
 	awk '$3 == \"unknown-version\" {\
-		print $2\"\t0\"\
+		print $2\"\t0\";\
 		next\
 	}\
 	{\


### PR DESCRIPTION
Addresses this issue upon updating package database.
```
jbara@localhost ~ $ sudo pmm --pm yay --sync
* sudo -u jbara strat -r arch yay -Sy
[sudo] password for jbara: 
:: Synchronizing package databases...
 core is up to date
 extra is up to date
* Caching arch:yay package database
awk: cmd. line:1: $3 == "unknown-version" {		print $2"	0"		next	}	{		sub(/[0-9]*:/, "", $3);		sub(/^[^0-9]*/, "", $3);		sub(/[^0-9.].*/, "", $3);		sub(/[.]$/, "", $3);		print $2"	"$3	}
awk: cmd. line:1:                          		         	  		^ syntax error
jbara@localhost ~ $ 
```