### PR TITLE
Fixed pmm: brl not found

### DIFF
--- a/src/slash-bedrock/libexec/pmm
+++ b/src/slash-bedrock/libexec/pmm
@@ -97,13 +97,15 @@ strata="$(
 	done | sort
 )"
 export strata
+export PATH=$PATH:/bedrock/bin
+
 aliases="$(
-	for alias in $(list_aliases); do
-		if is_enabled "${alias}" && has_attr "/bedrock/strata/${alias}" "show_pmm"; then
-			deref="$(brl deref "${alias}")"
-			echo "aliases[\"${alias}\"] = \"${deref}\""
-		fi
-	done | sort
+    for alias in $(list_aliases); do
+        if is_enabled "${alias}" && has_attr "/bedrock/strata/${alias}" "show_pmm"; then
+            deref="$(brl deref "${alias}")"
+            echo "aliases[\"${alias}\"] = \"${deref}\""
+        fi
+    done | sort
 )"
 export aliases
 initialize_awk_variables="${initialize_awk_variables}


### PR DESCRIPTION
Fixed an error in line 103 which gives an error that says this: /bedrock/libexec/pmm: line 103: brl: not found
```
/bedrock/libexec/pmm: line 103: brl: not found
/bedrock/libexec/pmm: line 103: brl: not found
* strat -r endeavouros pacman -Sy sh: line 1: strat: command not found
ERROR: endeavouros:pacman returned 127
```