### PR TITLE
Update bedrock.conf = Support Paths nixOS/nixpkgs

### DIFF
--- a/src/slash-bedrock/etc/bedrock.conf
+++ b/src/slash-bedrock/etc/bedrock.conf
@@ -281,21 +281,21 @@ zsh/zshenv = /bedrock/share/zsh/include-bedrock
 # A list of directories searched by various programs to find executables.
 #
 PREFIX:PATH = /bedrock/cross/pin/bin:/bedrock/bin
-INFIX:PATH  = /usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/games:/usr/games
+INFIX:PATH  = /usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/games:/usr/games:/nix/var/nix/profiles/system/sw/bin:/nix/var/nix/profiles/system/sw/sbin:/nix/var/nix/profiles/default/bin:/nix/var/nix/profiles/default/sbin
 SUFFIX:PATH = /bedrock/cross/bin
 
 #
 # A list of directories searched by the man executable to find documentation.
 #
 PREFIX:MANPATH = /bedrock/cross/pin/man:/bedrock/share/man
-INFIX:MANPATH  = /usr/local/share/man:/usr/share/man:/bedrock/cross/man
+INFIX:MANPATH  = /usr/local/share/man:/usr/share/man:/nix/var/nix/profiles/system/sw/share/man:/nix/var/nix/profiles/default/share/man:/bedrock/cross/man
 SUFFIX:MANPATH = /bedrock/cross/man
 
 #
 # A list of directories searched by the info executable to find documentation.
 #
 PREFIX:INFOPATH = /bedrock/cross/pin/info:/bedrock/share/info
-INFIX:INFOPATH  = /usr/local/share/info:/usr/share/info
+INFIX:INFOPATH  = /usr/local/share/info:/usr/share/info:/nix/var/nix/profiles/system/sw/share/info:/nix/var/nix/profiles/default/share/info
 SUFFIX:INFOPATH = /bedrock/cross/info
 
 #
@@ -303,14 +303,14 @@ SUFFIX:INFOPATH = /bedrock/cross/info
 # such as icons and application descriptions.
 #
 PREFIX:XDG_DATA_DIRS = /bedrock/cross/pin
-INFIX:XDG_DATA_DIRS  = /usr/local/share:/usr/share
+INFIX:XDG_DATA_DIRS  = /usr/local/share:/usr/share:/nix/var/nix/profiles/system/sw/share:/nix/var/nix/profiles/default/share
 SUFFIX:XDG_DATA_DIRS = /bedrock/cross
 
 #
 # Terminfo file locations
 #
 PREFIX:TERMINFO_DIRS = /bedrock/cross/pin/terminfo
-INFIX:TERMINFO_DIRS  = /usr/local/share/terminfo:/usr/share/terminfo
+INFIX:TERMINFO_DIRS  = /usr/local/share/terminfo:/usr/share/terminfo:/nix/var/nix/profiles/system/sw/share/terminfo:/nix/var/nix/profiles/default/share/terminfo
 SUFFIX:TERMINFO_DIRS = /bedrock/cross/terminfo
 
 #


### PR DESCRIPTION
# Support for nix environments of both types

Hello, I added this because a user must add a manual Nix environment, but with this, there is no need to modify bedrock.conf.

I also want to add share = /nix as well, but this does not make sense if you want to do it yourself

True bedrock linux does not support nixOS but this also helps nix pmm and nixOS-xos project.