### PR TITLE
Multithread stratum enabling

### DIFF
--- a/src/init/init
+++ b/src/init/init
@@ -452,8 +452,10 @@ for stratum in $(list_strata); do
 		continue
 	fi
 	notice "Enabling ${color_strat}${stratum}${color_norm}"
-	/bedrock/libexec/brl-enable --skip-crossfs "${stratum}"
+	/bedrock/libexec/brl-enable --skip-crossfs "${stratum}" &
 done
+
+wait
 
 step "Applying configuration"
 /bedrock/libexec/brl-apply --skip-repair


### PR DESCRIPTION
This greatly improves booting speed, especially when running a system with many strata