### PR TITLE
 [etcfs] fix set_caller_permissions

### DIFF
--- a/src/etcfs/etcfs.c
+++ b/src/etcfs/etcfs.c
@@ -320,9 +320,9 @@ static inline int set_caller_permissions(void)
 			return -ENOMEM;
 		}
 		int rv_heap;
-		if ((rv_heap = fuse_getgroups(rv, list)) < 0) {
+		if ((rv_heap = fuse_getgroups(rv, list_heap)) < 0) {
 			free(list_heap);
-			return rv;
+			return rv_heap;
 		}
 		if (rv_heap > rv) {
 			free(list_heap);


### PR DESCRIPTION
fuse_getgroups when rv > 64 should write to list_heap 

also, on error, it should return rv_heap; to pass the correct error code, otherwise it may think things succeeded when they did not. 